### PR TITLE
Using content_tag() rather than tag() for friendly html5 parser compatibility

### DIFF
--- a/lib/google_dfp.rb
+++ b/lib/google_dfp.rb
@@ -9,7 +9,8 @@ module GoogleDFP
       
       width, height = ad['size'].split("x")
       
-      tag :div,
+      content_tag :div,
+        "",
         :id    => "dfp-#{name}",
         :class => 'google-dfp',
         :style => "width: #{width}px; height: #{height}px",


### PR DESCRIPTION
See also: http://tiffanybbrown.com/2011/03/23/html5-does-not-allow-self-closing-tags/
