### PR TITLE
Allows the dfp script to sit in the head of a web page

### DIFF
--- a/google_dfp.gemspec
+++ b/google_dfp.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = "google_dfp"
-  s.version = '0.1.1'
+  s.version = '0.1.2'
   s.authors = ["Julian Kornberger"]
   s.email = ["jk+gemspec@digineo.de"]
   s.homepage = "https://github/digineo/google_dfp"

--- a/vendor/assets/javascripts/google_dfp.js
+++ b/vendor/assets/javascripts/google_dfp.js
@@ -19,11 +19,18 @@ $(function(){
   
   // async commands
   googletag.cmd.push(function() {
-    
+
     // define slots
     tags.each(function(){
       var $this = $(this);
-      googletag.defineSlot( $this.data('unit'), [$this.width(), $this.height()], this.id).addService(googletag.pubads());
+      googleAdSlot = googletag.defineSlot( $this.data('unit'), [$this.width(), $this.height()], this.id).addService(googletag.pubads());
+      if(typeof googletag.renderEndedCallback === "function") {
+        googleAdSlot.oldRenderEnded = googleAdSlot.renderEnded;
+        googleAdSlot.renderEnded = function() {
+          googleAdSlot.oldRenderEnded();
+          googletag.renderEndedCallback();
+	}
+      }
     })
     
     // enable services


### PR DESCRIPTION
This changeset will make the dfp script run once the DOM is loaded so all of the dfp tags have already been loaded.
