### PR TITLE
 Add fallback support for default ads

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ You can optionally specify a targeting hash:
 
 	<%= dfp_tag :leaderboard, { :country => 'US', :customer_job => 'teacher' } %>
 
+You are also able to supply a fallback name, which will be used if `name` cannot be found:
+
+  <%= dfp_tag :specific-leaderboard, {}, { :fallback => :house-leaderboard } %>
+
 Copyright
 ---------
 

--- a/lib/google_dfp.rb
+++ b/lib/google_dfp.rb
@@ -3,12 +3,12 @@ require 'google_dfp/size'
 require 'google_dfp/tag'
 
 module GoogleDFP
-  
+
   class Engine < ::Rails::Engine
   end
-  
+
   module ViewHelper
-    def dfp_tag(name, targeting=nil)
+    def dfp_tag(name, targeting={}, options={})
       tag  = GoogleDFP::Tag.get(name)
       data = tag.data
       data = data.merge(targeting: targeting) if targeting.present?
@@ -19,6 +19,18 @@ module GoogleDFP
         class: 'google-dfp',
         style: tag.style,
         data:  data
+    rescue ArgumentError => e
+      if options[:fallback].present?
+        # reset the name param to the fallback
+        name = options[:fallback]
+
+        # remove the fallback so we only retry once
+        options[:fallback] = nil
+        retry
+      else
+        # re-raise the exception
+        raise e
+      end
     end
   end
 


### PR DESCRIPTION
 Sdded support for an options parameter, accepting a key :fallback.

 Passing in {fallback: :my_default_ad} will cause the dfp_tag to attempt
 to use this value when the name parameter cannot be found.

 This is useful for dynamically generate ad names - which don't
 always exist - to provide a 'house' fallback.
